### PR TITLE
Add support for multiple session ids

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,37 @@
+name: phpspec and phpstan
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+    - name: Run test suite
+      run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "oxygen/core": "~0.8.0",
-        "oxygen/crud": "~0.7.0",
-        "oxygen/data": "~0.9.5",
-        "oxygen/preferences": "~0.3.5",
+        "oxygen/core": "~0.9.2",
+        "oxygen/crud": "~0.7.1",
+        "oxygen/data": "~0.9.8",
+        "oxygen/preferences": "~0.3.6",
         "illuminate/support": "~6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,10 @@
         ]
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12.18"
+        "phpstan/phpstan": "^0.12.18",
+        "phpspec/phpspec": "^6.1"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpspec run && vendor/bin/phpstan analyze src --level 1"
     }
 }

--- a/src/Controller/UpcomingEventsController.php
+++ b/src/Controller/UpcomingEventsController.php
@@ -2,11 +2,13 @@
 
 namespace OxygenModule\Events\Controller;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Oxygen\Crud\Controller\BasicCrudApi;
 use Oxygen\Crud\Controller\Previewable;
 use Oxygen\Crud\Controller\VersionableCrudApi;
 use Oxygen\Data\Repository\QueryParameters;
+use Oxygen\Preferences\PreferencesManager;
 use OxygenModule\Events\Fields\UpcomingEventFieldSet;
 use OxygenModule\Events\Repository\UpcomingEventRepositoryInterface;
 use Oxygen\Core\Blueprint\BlueprintManager;
@@ -26,29 +28,35 @@ class UpcomingEventsController extends VersionableCrudController {
         'resource' => 'Event',
         'pluralResource' => 'Events'
     ];
-    
+
     const PER_PAGE = 10;
+    /**
+     * @var PreferencesManager
+     */
+    private $preferences;
 
     /**
      * Constructs the UpcomingEventsController.
      *
-     * @param \OxygenModule\Events\Repository\UpcomingEventRepositoryInterface $repository
-     * @param \Oxygen\Core\Blueprint\BlueprintManager                          $manager
-     * @param \OxygenModule\Events\Fields\UpcomingEventFieldSet                $fields
+     * @param UpcomingEventRepositoryInterface $repository
+     * @param BlueprintManager $manager
+     * @param UpcomingEventFieldSet $fields
+     * @param PreferencesManager $preferences
      */
-    public function __construct(UpcomingEventRepositoryInterface $repository, BlueprintManager $manager, UpcomingEventFieldSet $fields) {
+    public function __construct(UpcomingEventRepositoryInterface $repository, BlueprintManager $manager, UpcomingEventFieldSet $fields, PreferencesManager $preferences) {
         parent::__construct($repository, $manager, $fields);
+        $this->preferences = $preferences;
     }
 
     protected function decoratePreviewContent($content) {
-        return view(Preferences::get('appearance.events::contentView'))->with('content', $content);
+        return view($this->preferences->get('appearance.events::contentView'))->with('content', $content);
     }
 
     /**
      * Find bookings from TryBooking's `bookingUrlId` and ticket index.
      *
      * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function findByTrybookingSessionId(Request $request) {
         $queryParameters = QueryParameters::make()

--- a/src/Controller/UpcomingEventsController.php
+++ b/src/Controller/UpcomingEventsController.php
@@ -14,7 +14,6 @@ use OxygenModule\Events\Repository\UpcomingEventRepositoryInterface;
 use Oxygen\Core\Blueprint\BlueprintManager;
 use Oxygen\Crud\Controller\Publishable;
 use Oxygen\Crud\Controller\VersionableCrudController;
-use Oxygen\Preferences\Facades\Preferences;
 
 class UpcomingEventsController extends VersionableCrudController {
 

--- a/src/Repository/DoctrineUpcomingEventRepository.php
+++ b/src/Repository/DoctrineUpcomingEventRepository.php
@@ -3,6 +3,7 @@
 namespace OxygenModule\Events\Repository;
 
 use Doctrine\ORM\NonUniqueResultException;
+use Exception;
 use OxygenModule\Events\Entity\UpcomingEvent;
 use DateTime;
 use Doctrine\ORM\NoResultException as DoctrineNoResultException;
@@ -24,7 +25,6 @@ class DoctrineUpcomingEventRepository extends Repository implements UpcomingEven
      *
      * @var string
      */
-
     protected $entityName = UpcomingEvent::class;
 
     /**
@@ -33,9 +33,8 @@ class DoctrineUpcomingEventRepository extends Repository implements UpcomingEven
      * @param int $howMany
      * @return array
      * @throws NoResultException if no results were found
-     * @throws \Exception
+     * @throws Exception
      */
-
     public function getLatest($howMany) {
         $currentDate = new DateTime();
 
@@ -63,7 +62,7 @@ class DoctrineUpcomingEventRepository extends Repository implements UpcomingEven
     /**
      * Finds event by trybooking session id
      *
-     * @param $sessionId
+     * @param int $sessionId
      * @return UpcomingEvent
      * @throws NonUniqueResultException
      */

--- a/src/Repository/UpcomingEventRepositoryInterface.php
+++ b/src/Repository/UpcomingEventRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace OxygenModule\Events\Repository;
 
 use Oxygen\Data\Repository\RepositoryInterface;
+use OxygenModule\Events\Entity\UpcomingEvent;
 
 interface UpcomingEventRepositoryInterface extends RepositoryInterface {
 
@@ -17,8 +18,8 @@ interface UpcomingEventRepositoryInterface extends RepositoryInterface {
     /**
      * Finds event by trybooking session id
      *
-     * @param $sessionId
-     * @return event
+     * @param int $sessionId
+     * @return UpcomingEvent
      */
     public function findByTrybookingSessionId($sessionId);
 


### PR DESCRIPTION
This change is backwards compatible to the database schema, since we use the 'simple_array' doctrine type which is a comma-separated list of values. Hence a single value the same as a list of size 1.